### PR TITLE
Update example-dronekit.md with await_params

### DIFF
--- a/book/example-dronekit.md
+++ b/book/example-dronekit.md
@@ -45,16 +45,12 @@ From Python, you connect to Solo on this port using the `connect()` method as sh
 
 ```py
 from droneapi import connect
-import time
 
 # Connect to UDP endpoint.
-vehicle = connect('udpin:0.0.0.0:14550')
-
-# Wait for parameters to accumulate.
-time.sleep(5)
+vehicle = connect('udpin:0.0.0.0:14550', await_params=True)
 ```
 
-The `connect()` method returns a Vehicle class with attributes initially set to `None`. We normally wait a few seconds after connecting to allow these to be populated from received MAVLink messages.
+The `connect()` method returns a `Vehicle` object that can be used to observe and control the drone.
 
 
 


### PR DESCRIPTION
This adds await_params=True to the connect, and removes the 5s sleep. I haven't similarly updated the code yet - I'll do so if this gets integrated, which will tell me you're happy with this change.