### PR TITLE
Update example to use latest DroneKit

### DIFF
--- a/book/advanced-python.md
+++ b/book/advanced-python.md
@@ -7,7 +7,7 @@ This guide shows how to bundle Python code locally on your computer and expand i
 
 First create and navigate to a new directory on your host computer. This directory will be populated with your own Python scripts and all their dependencies. The entire directory will then be sent to Solo. 
 
-Start by creating a virtual environment on your host computer:
+Start by creating a virtual environment on your host computer (Linux/Mac OS X):
 
 <div class="host-code"></div>
 
@@ -25,7 +25,20 @@ We want to configure our environment to not compile any C extensions. We can do 
 echo 'import sys; import distutils.core; s = distutils.core.setup; distutils.core.setup = (lambda s: (lambda **kwargs: (kwargs.__setitem__("ext_modules", []), s(**kwargs))))(s)' > env/lib/python2.7/site-packages/distutils.pth
 ```
 
-Now you can install Python packages using `pip install`. 
+<aside class="note">
+The commands above are for Linux! Windows has slightly different commands (see the [User guide](http://virtualenv.readthedocs.org/en/latest/userguide.html)) so instead do:
+
+<div class="host-code"></div>
+
+```sh
+pip install virtualenv
+virtualenv env
+env\Scripts\activate.bat
+echo 'import sys; import distutils.core; s = distutils.core.setup; distutils.core.setup = (lambda s: (lambda **kwargs: (kwargs.__setitem__("ext_modules", []), s(**kwargs))))(s)' > env\Lib\site-packages\distutils.pth
+```
+</aside>
+
+Now you can install Python packages into the new environment using `pip install`. 
 
 <aside class="caution">
 When modules require a C extension, they will fail silently. Test your code!
@@ -49,22 +62,34 @@ pip wheel -r ./requirements.txt --build-option="--plat-name=py27"
 
 This installs all the dependencies in `requirements.txt` as Python wheel files, which are source code packages.
 
-Next, you can move this entire directory over to Solo using *rsync*:
+Next, you can move this entire directory (except for *env*) over to Solo. The following command shows how to do this using *rsync*:
+
+<div class="host-code"></div>
+
+```sh
+rsync -avz --exclude="*.pyc" --exclude="env" ./ root@10.1.1.10:/opt/my_python_code
+```
+
+<aside class="tip">
+On Windows, you may prefer to copy the folder using a graphical tool like *WinSCP* ([download here]([WinSCP](https://winscp.net/download/winscp576setup.exe)).
+</aside>
+
+Install _pip_ on Solo (from the host computer):
 
 <div class="host-code"></div>
 
 ```sh
 solo install-pip
-rsync -avz --exclude="*.pyc" --exclude="env" ./ root@10.1.1.10:/opt/my_python_code
 ```
 
-SSH into Solo and navigate to the newly made directory (above `/opt/my_python_code`). Make sure you have _pip_ and _virtualenv_ installed:
+SSH into Solo and install _virtualenv_:
+
 
 ```
 pip install virtualenv
 ```
 
-Finally, run these commands in your Solo code directory:
+Finally, navigate to the newly made code directory (`/opt/my_python_code`) and run these commands:
 
 ```sh
 virtualenv env

--- a/book/example-dronekit.md
+++ b/book/example-dronekit.md
@@ -85,9 +85,14 @@ print " Armed: %s" % vehicle.armed    # settable
 
 ## Installing _dkexample_
 
+Installation from Linux/Mac OS X and Windows are very similar. The main differences are that
+some of the instructions for using *Virtualenv* are slightly different (see the [User guide](http://virtualenv.readthedocs.org/en/latest/userguide.html)) and tools like *WinScp* are more familiar to Windows users than *Rsync*.
+
 <aside class="note">
 See [Bundling Python](advanced-python.html) for an explanation of the following steps.
 </aside>
+
+### Installing _dkexample_ from Linux/Mac OS X
 
 Clone the [solodevguide](https://github.com/3drobotics/solodevguide) repository and cd into the [examples/dkexample](https://github.com/3drobotics/solodevguide/tree/master/examples/dkexample) directory.
 
@@ -101,26 +106,12 @@ virtualenv env
 echo 'import sys; import distutils.core; s = distutils.core.setup; distutils.core.setup = (lambda s: (lambda **kwargs: (kwargs.__setitem__("ext_modules", []), s(**kwargs))))(s)' > env/lib/python2.7/site-packages/distutils.pth
 ```
 
-<aside class="note">
-On Windows, the last command should instead be:
-
-<div class="host-code"></div>
-
-```sh
-echo 'import sys; import distutils.core; s = distutils.core.setup; distutils.core.setup = (lambda s: (lambda **kwargs: (kwargs.__setitem__("ext_modules", []), s(**kwargs))))(s)' > env\Lib\site-packages\distutils.pth
-```
-</aside>
-
 Activate the virtual environment:
 
 <div class="host-code"></div>
 
 ```sh
-# On Linux
 source ./env/bin/activate
-
-# On Windows
-env\Scripts\activate.bat
 ```
 
 Install the Python dependencies locally, and then package them for Solo:
@@ -137,13 +128,16 @@ Next, and every time we make changes to Python, we can sync our code to Solo usi
 <div class="host-code"></div>
 
 ```sh
-solo install-pip
 rsync -avz --exclude="*.pyc" --exclude="env" ./ root@10.1.1.10:/opt/dkexample
 ```
 
-<aside class="note">
-It is possible to install *rsync* on Windows and use the above command. Alternatively you can use *WinSCP*, create the **opt** folder in Solo's root and then drag/drop the **dkexample** folder into it (you do not need to copy/can delete the **env** folder).
-</aside>
+Install _pip_ on Solo (from the host computer):
+
+<div class="host-code"></div>
+
+```sh
+solo install-pip
+```
 
 Now SSH into Solo. Navigate to the example directory and install packages:
 
@@ -156,4 +150,69 @@ pip install --no-index ./wheelhouse/* -UI
 ```
 
 Then you can run `python example.py` to see Solo's telemetry output in realtime to the console.
+
+
+### Installing _dkexample_ from Windows
+
+Clone the [solodevguide](https://github.com/3drobotics/solodevguide) repository and cd into the [examples/dkexample](https://github.com/3drobotics/solodevguide/tree/master/examples/dkexample) directory.
+
+In this folder, prepare your environment by running:
+
+<div class="host-code"></div>
+
+```sh
+pip install virtualenv
+virtualenv env
+echo 'import sys; import distutils.core; s = distutils.core.setup; distutils.core.setup = (lambda s: (lambda **kwargs: (kwargs.__setitem__("ext_modules", []), s(**kwargs))))(s)' > env\Lib\site-packages\distutils.pth
+```
+
+
+Activate the virtual environment:
+
+<div class="host-code"></div>
+
+```sh
+env\Scripts\activate.bat
+```
+
+Install the Python dependencies locally, and then package them for Solo:
+
+<div class="host-code"></div>
+
+```sh
+pip install -r requirements.txt
+pip wheel -r ./requirements.txt --build-option="--plat-name=py27"
+```
+
+Next we copy our code into Solo. 
+
+* Download and install [WinSCP](https://winscp.net/download/winscp576setup.exe)
+* Create the **opt** folder in Solo's root and then drag/drop the **dkexample** folder into it (you do not need to copy the **env** folder).
+
+<aside class="note">
+It is possible to sync code by using *rsync* on Windows using the same commands 
+[as in Linux/Mac OS X](#installing-dkexample-from-linux-mac-os-x).
+</aside>
+
+Install _pip_ on Solo (from the host computer):
+
+<div class="host-code"></div>
+
+```sh
+solo install-pip
+```
+
+
+Now SSH into Solo. Navigate to the example directory and install packages:
+
+```sh
+pip install virtualenv
+cd /opt/dkexample
+virtualenv env
+source ./env/bin/activate
+pip install --no-index ./wheelhouse/* -UI
+```
+
+Then you can run `python example.py` to see Solo's telemetry output in realtime to the console.
+
 

--- a/examples/dkexample/example.py
+++ b/examples/dkexample/example.py
@@ -1,24 +1,31 @@
-from droneapi import connect, VehicleMode
+from dronekit import connect, VehicleMode
 import time
 
 # Connect to UDP endpoint
-vehicle = connect('udpin:0.0.0.0:14550', await_params=True)
+vehicle = connect('udpin:0.0.0.0:14550', wait_ready=True)
 
 # Wait for parameters to accumulate.
-time.sleep(5)
+#time.sleep(5)
 
 # Get all vehicle attributes (state)
 print "\nGet all vehicle attribute values:"
-print " Location: %s" % vehicle.location
+print " Global Location: %s" % vehicle.location.global_frame
+print " Global Location (relative altitude): %s" % vehicle.location.global_relative_frame
+print " Local Location: %s" % vehicle.location.local_frame
 print " Attitude: %s" % vehicle.attitude
 print " Velocity: %s" % vehicle.velocity
 print " GPS: %s" % vehicle.gps_0
-print " Groundspeed: %s" % vehicle.groundspeed
-print " Airspeed: %s" % vehicle.airspeed
 print " Mount status: %s" % vehicle.mount_status
 print " Battery: %s" % vehicle.battery
+print " EKF OK?: %s" % vehicle.ekf_ok
+print " Last Heartbeat: %s" % vehicle.last_heartbeat
 print " Rangefinder: %s" % vehicle.rangefinder
 print " Rangefinder distance: %s" % vehicle.rangefinder.distance
 print " Rangefinder voltage: %s" % vehicle.rangefinder.voltage
+print " Heading: %s" % vehicle.heading
+print " Is Armable?: %s" % vehicle.is_armable
+print " System status: %s" % vehicle.system_status.state
+print " Groundspeed: %s" % vehicle.groundspeed    # settable
+print " Airspeed: %s" % vehicle.airspeed    # settable
 print " Mode: %s" % vehicle.mode.name    # settable
 print " Armed: %s" % vehicle.armed    # settable

--- a/examples/dkexample/requirements.txt
+++ b/examples/dkexample/requirements.txt
@@ -1,4 +1,4 @@
 protobuf==3.0.0a1
 requests==2.5.1
 wheel==0.24.0
-dronekit==2.0.0c1
+dronekit==2.0.2


### PR DESCRIPTION
This updates the dk-example to 2.0.2 and also adds separate instructions for Windows developers (who have a different activate command, and who may not have rsync).

Also update the "Bundling" doc to also include Windows instructions