### PR TITLE
Update with clear instructions for using solo script and tidy example

### DIFF
--- a/book/SUMMARY.md
+++ b/book/SUMMARY.md
@@ -12,10 +12,12 @@ This is the summary of the solodevguide.
    * [External Resources](starting-resources.md)
 * Concepts
    * [Architectural Overview](concept-architecture.md)
+   * [DroneKit](concept-dronekit.md)
    * [Smart Shots](concept-smartshot.md)
    * [System Services](concept-service.md)
    * [Video Pipeline](concept-video.md)
 * Software Examples
+   * [Running the Examples](example-get-started.md)
    * [Hello World (from above)!](example-helloworld.md)
    * [Running a Webserver](example-webserver.md)
    * [Skywriter Controller](example-skywriter.md)

--- a/book/advanced-python.md
+++ b/book/advanced-python.md
@@ -1,9 +1,12 @@
-# Bundling Python
+# Advanced Python Bundling
 
-This guide shows how to bundle Python code locally on your computer and expand it in a virtual environment ([virtualenv](starting-installing.html#installing-packages-into-a-virtualenv)) on Solo. This approach has two benefits:
+The best way to deploy and run Python code on your Solo is to use the *Solo CLI*, as [described here](concept-dronekit.html#deploying-scripts-to-solo).
+This approach uses just two simple commands to package your scripts and their dependencies, uploading the package to Solo, and running the file.
 
-1. No Internet connection or reliance on package management on Solo is needed.
-2. Packages are installed in a virtual environment, so they don't collide with the global Solo namespace.
+This guide shows the method that was used prior to introduction of *Solo CLI* packaging. It may be of interest/use to some Solo developers.
+
+
+## Manual bundling
 
 First create and navigate to a new directory on your host computer. This directory will be populated with your own Python scripts and all their dependencies. The entire directory will then be sent to Solo. 
 

--- a/book/concept-dronekit.md
+++ b/book/concept-dronekit.md
@@ -1,0 +1,112 @@
+# DroneKit
+
+[DroneKit-Python](http://python.dronekit.io/) is a Python library that can be used to connect to, monitor and control a vehicle. You can use it to write your own scripts and interact with Solo from either a ground station or from Solo's onboard companion computer.
+
+<aside class="note">
+Solo uses [DroneKit-Python v1.1](http://python.dronekit.io/) internally to develop its [Smart Shots](concept-smartshot.html). When you create your own DroneKit-Python scripts you can run them with the *latest* version of DroneKit in a virtual environment.
+</aside>
+
+Working with DroneKit-Python is virtually the same on any platform/vehicle. Developers should read the [DroneKit-Python Documentation](http://python.dronekit.io/) in order to understand the key concepts.
+
+This topic provides a very brief introduction to the "nuances" of working with DroneKit-Python on Solo. It explains how a script should connect to Solo, how to deploy and run scripts on the device, some limitations of using DroneKit scripts (as opposed to using [Smart Shots](concept-smartshot.html)), and how to access useful platform features. 
+
+<aside class="tip">
+You can try out most of the ideas presented here by [running the examples](example-get-started.html).
+</aside>
+
+
+
+## Connecting to Solo
+
+The MAVLink telemetry protocol (used to communicate with Solo) is served on UDP port 14550. Scripts can connect as a UDP client to `udpin:0.0.0.0:14550` from any external device connected to its network or from Solo's terminal.
+
+From Python, you connect to Solo on this port using the `connect()` method as shown:
+
+<div class="any-code"></div>
+
+```py
+from dronekit import connect
+
+# Connect to UDP endpoint (and wait for default attributes to accumulate)
+print 'Connecting to Solo ...'
+vehicle = connect('udpin:0.0.0.0:14550', wait_ready=True)
+```
+
+The `connect()` method returns a `Vehicle` object that can be used to observe and control the drone.
+
+Other than the connection string used for Solo, all other aspects of calling the API are the same as in the [DroneKit-Python documentation](http://python.dronekit.io/).
+
+
+## Deploying scripts to Solo
+
+Scripts can be deployed and run on Solo using the [Solo CLI](starting-utils.html#deployingrunning-dronekit-scripts-on-solo). The CLI takes care of packaging all the scripts in a folder along with all dependencies listed in the folder's **requirements.txt** file. It can then be used to transfer the package to Solo, install it, and run a specified script in a virtual environment.
+
+<aside class="note">
+This approach has several benefits over using Solo's "inbuilt" version of DroneKit-Python:
+
+1. No Internet connection or reliance on package management on Solo is needed.
+1. Packages are installed in a virtual environment, so they don't collide with the global Solo namespace.
+1. You can always use the most recent DroneKit-Python in your examples (the inbuilt version is updated less regularly).
+1. The *Solo CLI* is simple to use and will already be present developer's computers. 
+</aside>
+
+
+
+### solo script pack
+
+`solo script` is used to package all code and dependencies needed to run a script. It creates an archive that can be deployed to Solo (as described in the next section).
+
+The command is run inside a directory which should contain all needed Python scripts along with a `requirements.txt` file listing all the needed `pip` dependencies. Minimally this will include the latest version of DroneKit:
+
+   <div class="any-code"></div>
+
+   ```
+   dronekit>=2.0.0
+   ```
+
+<aside class="tip">
+The system will install fresh copies of any listed files into the script's virtual environment on Solo. The exception is OpenCV; if this is listed then a system version will be used instead. 
+</aside>
+
+Open a terminal, navigate to the directory to package, and enter the following command:
+
+<div class="host-code"></div>
+
+```
+solo script pack
+```
+
+After some processing, this will create an archive called `solo-script.tar.gz` in your current directory, or display an error if the process could not complete.
+
+
+### solo script run ...
+
+In order to deploy the script archive and run the app, first connect to Solo's wifi network. 
+
+Then enter the following command to upload the script archive to Solo, unpack it and its dependencies, and then attempt to run the specified python script (`yourscriptname.py`):
+
+<div class="host-code"></div>
+
+```
+solo script run yourscriptname.py
+```
+
+
+
+## Accessing Solo Features
+
+DroneKit-Python scripts can use any features of the underlying platform that are (or can be made) accessible to Python. 
+
+For example, DroneKit-Python does not have any API for direct access to camera/video (though it can control the Camera gimbal). However it can use platform services to access video frames and libraries like *OpenCv* for post-processing. See [this example](example-opencv.html) for more information.
+
+
+## DroneKit-Python Limitations
+
+There is currently no inbuilt support for:
+
+* Launching DroneKit-Python scripts from the Controller.
+* Launching DroneKit-Python scripts on system boot.
+* Passing parameters to a script after it has started.
+* Pausing or restarting a script due to external interaction.
+
+Some of these features are available to [Smart Shots](concept-smartshot.html).

--- a/book/example-get-started.md
+++ b/book/example-get-started.md
@@ -1,0 +1,103 @@
+# Running the Examples
+
+This guide contains a number of examples showing how to use DroneKit on Solo. These are stored on Github in separate folders under 
+[solodevguide/examples](https://github.com/3drobotics/solodevguide/tree/master/examples).
+
+The examples can be run locally from your development computer to communicate with either Solo or a simulated copter, or they can be run on Solo itself.
+
+
+## Running on Solo
+
+The following instructions can be used to package each of the examples on a host computer, then deploy and run them on Solo:
+
+1. Clone the solodevguide repo and navigate to your target example (in this example: "helloworld"):
+
+   <div class="host-code"></div>
+
+   ```
+   git clone https://github.com/3drobotics/solodevguide
+   cd solodevguide/examples/helloworld
+   ```
+
+1. [Connect your host computer and Solo to the Internet](starting-utils.html#connecting-solo-to-the-internet) 
+   (using the ``solo wifi`` command).
+   
+1. Package the current example folder for installation on Solo using the ``solo script pack command``:
+
+   <div class="host-code"></div>
+
+   ```
+   solo script pack
+   ```
+
+  After some processing, this will create an archive called `solo-script.tar.gz` 
+  in your current directory, or display an error if the process could not complete.
+ 
+1. Install the script archive on Solo and run a specified script 
+   using the ``solo script run`` command (your computer 
+   must be connected to the Solo wifi). In this example we start **helloworld.py**: 
+
+   <div class="host-code"></div>
+
+   ```
+   solo script run helloworld.py
+   ```
+
+<aside class="tip">
+More general information can be found in [DroneKit:Deploying scripts to Solo](concept-dronekit.html#deploying-scripts-to-solo).
+</aside>
+
+
+## Running from a host PC to Solo
+
+The following instructions explain how to run the examples locally from a host PC, communicating with Solo.
+
+1. Clone the solodevguide repo and navigate to your target example (in this example: "helloworld"):
+
+   <div class="host-code"></div>
+
+   ```
+   git clone https://github.com/3drobotics/solodevguide
+   cd solodevguide/examples/helloworld
+   ```
+
+1. Connect your PC to the Solo WiFi network.
+
+1. Run the target script as shown:
+
+   <div class="host-code"></div>
+
+   ```
+   python helloworld.py 
+   ```
+   
+   <aside class="tip">There is no need to specify a connection string as the example uses the Solo port by default (`'udpin:0.0.0.0:14550'`), and this is accessible while we're on the Solo WiFi network.</aside>
+
+
+## Running from a host PC to Simulator
+
+The following instructions explain how to run the examples locally from a host PC, communicating with a simulated device.
+
+1. Set up a simulated vehicle using the instructions in the [DroneKit documents here](http://python.dronekit.io/guide/sitl_setup.html).
+
+1. Clone the solodevguide repo and navigate to your target example (in this example: "helloworld"):
+
+   <div class="host-code"></div>
+
+   ```
+   git clone https://github.com/3drobotics/solodevguide
+   cd solodevguide/examples/helloworld
+   ```
+
+1. Run the target script, specifying the SITL loopback address as shown:
+
+   <div class="host-code"></div>
+
+   ```
+   python helloworld.py 127.0.0.1:14550
+   ```
+   
+   <aside class="note">Depending on how you set up the simulator, the loopback address may instead be `tcp:127.0.0.1:5760`.</aside>
+   
+
+

--- a/book/example-helloworld.md
+++ b/book/example-helloworld.md
@@ -1,35 +1,24 @@
-# Hello World (from above)!
+# Hello World (from the sky)!
 
-*[DroneKit](http://dronekit.io/)* is a library that can be used to monitor and control a connected vehicle. Solo uses [DroneKit-Python v1.1](http://python.dronekit.io/) internally to develop its [Smart Shots](concept-smartshot.html). 
+This example demonstrates a basic [DroneKit](concept-dronekit.html) script that retrieves vehicle information including position, speed, battery life, current flight mode etc.
 
-This example shows how to install the *latest* version of DroneKit into a virtual environment and run a basic script to retrieve vehicle information including position, speed, battery life, current flight mode etc.
-
-**NOTE:** To run this example, please `git clone` or download all the files in the [helloworld folder](https://github.com/3drobotics/solodevguide/tree/master/examples/helloworld) on Github.
-
-## Installing DroneKit on Solo
-
-The process for bundling the example (including DroneKit) is described below in [Installing _dkexample_](#installing-dkexample) (and more generally in [Bundling Python](advanced-python.html)). 
-
-The libraries that are bundled are defined in the example `requirements.txt` file:
-
-<div class="any-code"></div>
-
-```
-dronekit>=2.0.0
-```
+<aside class="note">
+This example is safe to run both locally and on Solo itself, because it doesn't arm the vehicle or start the motors.
+</aside>
 
 
-## Connecting to Solo
+## How does it work?
 
-The MAVLink telemetry protocol (used to communicate with Solo) is served on UDP port 14550. You can set up downstream applications to connect as a UDP client to `udpin:0.0.0.0:14550` from any external device connected to its network (or from Solo's terminal).
+### Connecting to Solo
 
-From Python, you connect to Solo on this port using the `connect()` method as shown:
+The MAVLink telemetry protocol (used to communicate with Solo) is served on UDP port 14550.
+
+The code to connect to Solo is shown below. This takes an argument for the connection string, but uses `udpin:0.0.0.0:14550` by default.  
 
 <div class="any-code"></div>
 
 ```py
-from dronekit import connect, VehicleMode
-import time
+from dronekit import connect
 import sys
 
 # Connect to UDP endpoint (and wait for default attributes to accumulate)
@@ -41,10 +30,9 @@ vehicle = connect(target, wait_ready=True)
 The `connect()` method returns a `Vehicle` object that can be used to observe and control the drone.
 
 
+### Retrieve parameters
 
-## Retrieve parameters
-
-The vehicle attributes can then be read, as shown:
+The vehicle attributes are then read, as shown:
 
 <div class="any-code"></div>
 
@@ -66,38 +54,104 @@ print " Is Armable?: %s" % vehicle.is_armable
 print " Armed: %s" % vehicle.armed
 ```
 
-## Running helloworld.py on Solo
+### Close the vehicle
 
-Using the *Solo CLI*, we can directly run scripts on Solo. The requirements for this are the following:
+The final step in any script is to close the `Vehicle` object, which releases any resources owned by the script:
 
-1. All Python code should live in the folder you run the `solo script` command in.
-1. All Python package dependencies should be specified in the `requirements.txt` file.
+<div class="any-code"></div>
 
-Because we have done the above, we are able to complete the first step in deploying code.
-
-### `solo script pack`
-
-First we have to package our code into an archive that can be deployed to Solo. First, connect, ensure your computer is connected to the Internet (or if you are connected to Solo, you have run `solo wifi`). Then run the following:
-
-<div class="host-code"></div>
-
-```
-solo script pack
+```py
+vehicle.close()
+print "Done."
 ```
 
-After some processing, this will create an archive called `solo-script.tar.gz` in your current directory, or display an error if the process could not complete.
 
-### `solo script run ...`
+## Running the example
 
-Now that we have a script archive, we can run it. Connect to Solo's wifi network. Next, run:
+The process for running the example is exactly described in [Running the Examples](example-get-started.html) (this topic shows how to run the example on Solo, and locally on a computer communicating with either Solo or a simulated vehicle).  There is addition information on running DroneKit scripts in [DroneKit:Deploying scripts to Solo](concept-dronekit.html#deploying-scripts-to-solo).
 
-<div class="host-code"></div>
+To run the example locally:
 
-```
-solo script run helloworld.py
-```
+1. Clone the solodevguide repo and navigate to the "helloworld" example:
 
-This will upload the script archive to Solo, unpack it and its dependencies, and then attempt to run the `helloworld.py` script as indicated in the command line.
+   <div class="host-code"></div>
+
+   ```
+   git clone https://github.com/3drobotics/solodevguide
+   cd solodevguide/examples/helloworld
+   ```
+   
+1. Connect your PC to the Solo Wifi network
+
+1. Run the target script as shown:
+
+   <div class="host-code"></div>
+
+   ```
+   python helloworld.py 
+   ```
+   
+   After running the example you should see the following output on the terminal:
+
+   ```
+   >helloworld.py
+   Connecting to udpin:0.0.0.0:14550...
+   >>> PreArm: Need 3D Fix
+   >>> APM:Copter solo-1.2.19 (331103b2)
+   >>> PX4: 60133536 NuttX: d48fa307
+   >>> Frame: QUAD
+   >>> PX4v2 0020003C 33345112 32363238
+   Vehicle state:
+    Global Location: LocationGlobal:lat=0.0,lon=0.0,alt=-0.02
+    Global Location (relative altitude): LocationGlobalRelative:lat=0.0,lon=0.0,alt=-0.02
+    Local Location: LocationLocal:north=None,east=None,down=None
+    Attitude: Attitude:pitch=0.0127924475819,yaw=2.03015804291,roll=-0.0335337780416
+    Velocity: [-0.01, -0.02, -0.01]
+    Battery: Battery:voltage=16.055,current=0.87,level=77
+    Last Heartbeat: 0.826999902725
+    Heading: 116
+    Groundspeed: 0.0
+    Airspeed: 0.0
+    Mode: LOITER
+    Is Armable?: False
+    Armed: False>
+   >> PreArm: Need 3D Fix
+
+   Done.
+   ```   
+   
+   
+To run the example on Solo
+
+1. [Connect your host computer and Solo to the Internet](starting-utils.html#connecting-solo-to-the-internet) 
+   (using the ``solo wifi`` command).
+   
+1. After navigating to the *helloworld* directory, package the current example folder for installation on Solo using the ``solo script pack command``:
+
+   <div class="host-code"></div>
+
+   ```
+   solo script pack
+   ```
+   
+   The libraries that are bundled are defined in the [requirements.txt](https://github.com/3drobotics/solodevguide/blob/master/examples/helloworld/requirements.txt) file in the example directory. For this example DroneKit itself is the only dependency:
+   
+   <div class="any-code"></div>
+
+   ```
+   dronekit>=2.0.0
+   ```
+
+   After some processing, this will create an archive called `solo-script.tar.gz` 
+   in your current directory, or display an error if the process could not complete.
+ 
+1. Install the script archive on Solo and run the example using the ``solo script run`` command: 
+
+   <div class="host-code"></div>
+
+   ```
+   solo script run helloworld.py
+   ```
 
 If this is successful, you will see the same result as above when you ran your command locally. The only difference here is that code is now running on Solo: your first step toward programming powerful applications that live on and control your drone autonomously.
 

--- a/book/starting-utils.md
+++ b/book/starting-utils.md
@@ -34,9 +34,10 @@ Once installed, you should be able to run `solo` from your command line to see t
 $ solo
 Usage:
   solo info
-  solo wifi --name=<n> --password=<p>
-  solo update (solo|controller|both) (latest|<version>)
-  solo revert (solo|controller|both) (latest|current|factory|<version>)
+  solo wifi --name=<n> [--password=<p>]
+  solo flash (drone|controller|both) (latest|current|factory|<version>) [--clean]
+  solo flash --list
+  solo flash pixhawk <filename>
   solo provision
   solo resize
   solo logs (download)
@@ -44,6 +45,7 @@ Usage:
   solo install-smart
   solo install-runit
   solo video (acquire|restore)
+  solo script [<arg>...]  
 ```
 
 Specific information about what these commands do is given in the following sections and on the [*Solo CLI* README](https://github.com/3drobotics/solo-cli).
@@ -107,6 +109,35 @@ To install `pip` directly on Solo:
 ```
 solo install-pip
 ```
+
+## Deploying/running DroneKit scripts on Solo
+
+Use the ``solo script pack`` command to package a folder containing DroneKit-Python scripts 
+and any dependencies into an archive for deployment to Solo.  
+The host computer must be connected to the Internet, and the folder must contain a 
+**requirements.txt** file listing 
+the (PyPi) dependencies:
+
+<div class="host-code"></div>
+
+```
+solo script pack
+```
+
+If successful, the command will create an archive in the `solo-script.tar.gz` in the current directory.
+
+Deploy this archive to Solo and run a specified script using the ``solo script run <scripname>`` command. 
+The host computer must be connected to the Solo wifi network, and Solo must also be connected to the 
+Internet.
+
+For example, to deploy and run the [helloworld example](example-helloworld.html):
+
+<div class="host-code"></div>
+
+```
+solo script run helloworld.py
+```
+
 
 ## Downloading Logs
 

--- a/examples/helloworld/helloworld.py
+++ b/examples/helloworld/helloworld.py
@@ -1,5 +1,4 @@
-from dronekit import connect, VehicleMode
-import time
+from dronekit import connect
 import sys
 
 # Connect to UDP endpoint (and wait for default attributes to accumulate)
@@ -22,5 +21,6 @@ print " Airspeed: %s" % vehicle.airspeed
 print " Mode: %s" % vehicle.mode.name
 print " Is Armable?: %s" % vehicle.is_armable
 print " Armed: %s" % vehicle.armed
-print ""
+
+vehicle.close()
 print "Done."


### PR DESCRIPTION
This adds a more clear "general" conceptual description of what DroneKit-Python offers, which is focused on the differences to bog-standard DK-Python and include and overview of how to deploy to Solo.

I've also added a "Running the example" topic which shows how to run on solo, locally to solo and locally to a simulator. 

The Helloworld is updated so that now it makes a little more sense. It shows how to use both locally and on solo.

All that is quite a lot of duplication, but on the other hand, it is a very consistent story.

@tcr3dr @mrpollo Would appreciate your review. After this is merged I can look at the other examples.