### PR TITLE
fixes tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ sudo: false
 node_js:
   - "5"
 before_script:
-  - npm install -g grunt-cli gitbook-cli
   - gitbook install book
 after_success:
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 sudo: false
 node_js:
-  - "4"
+  - "5"
 before_script:
   - npm install -g grunt-cli gitbook-cli
   - gitbook install book

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -96,9 +96,23 @@ module.exports = function (grunt) {
     });
   });
 
+  grunt.registerTask('debuggitbookfiles', 'print the contents of the gitbook website tree', function () {
+    var done = this.async();
+    var spawn = require('child_process').spawn;
+    var p = spawn('ls', ['-la', 'book/_book/gitbook/website'], {
+      cwd: __dirname
+    });
+    p.stdout.on('data', function (data) {
+      grunt.log.writeln("ls -la book/_book/gitbook/website");
+      grunt.log.writeln(data);
+      done();
+    });
+  });
+
   // Create Default Task
   grunt.registerTask('check', [
     'gitbook',
+    'debuggitbookfiles',
     'http-server:check',
     'linkChecker',
   ]);

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -97,7 +97,6 @@ module.exports = function (grunt) {
   });
 
   grunt.registerTask('debuggitbookfiles', 'print the contents of the gitbook website tree', function () {
-    var done = this.async();
     var spawn = require('child_process').spawn;
     var p = spawn('ls', ['-la', 'book/_book/gitbook/website'], {
       cwd: __dirname
@@ -105,7 +104,6 @@ module.exports = function (grunt) {
     p.stdout.on('data', function (data) {
       grunt.log.writeln("ls -la book/_book/gitbook/website");
       grunt.log.writeln(data);
-      done();
     });
   });
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -36,6 +36,11 @@ module.exports = function (grunt) {
           maxConcurrency: 20,
           initialPort: 4000,
           supportedMimeTypes: [/html/i],
+          callback: function (crawler) {
+            crawler.addFetchCondition(function(url) {
+              return !url.path.match(/\/website\//);
+            });
+          }
         }
       }
     },

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # Solo Developer Guide
 
-This guide is published online at: http://dev.3dr.com/
+[![Build Status](https://travis-ci.org/3drobotics/solodevguide.svg?branch=master)](https://travis-ci.org/3drobotics/solodevguide)
+[![Circle CI](https://circleci.com/gh/3drobotics/solodevguide.svg?style=svg)](https://circleci.com/gh/3drobotics/solodevguide)
+
+This guide is published online at: [dev.3dr.com](http://dev.3dr.com/)
 
 To start editing, install [GitBook](https://www.gitbook.com/) (requires Node.js):
 

--- a/book/concept-dronekit.md
+++ b/book/concept-dronekit.md
@@ -8,7 +8,7 @@ Solo uses [DroneKit-Python v1.1](http://python.dronekit.io/) internally to devel
 
 Working with DroneKit-Python is virtually the same on any platform/vehicle. Developers should read the [DroneKit-Python Documentation](http://python.dronekit.io/) in order to understand the key concepts.
 
-This topic provides a very brief introduction to the "nuances" of working with DroneKit-Python on Solo. It explains how a script should connect to Solo, how to deploy and run scripts on the device, some limitations of using DroneKit scripts (as opposed to using [Smart Shots](concept-smartshot.html)), and how to access useful platform features.
+This topic provides a very brief introduction to the "nuances" of working with DroneKit-Python on Solo. It explains how a script should connect to Solo, how to deploy and run scripts on the device, some limitations of using DroneKit scripts (as opposed to using [Smart Shots](concept-smartshot.html)), and how to access useful platform features. 
 
 <aside class="tip">
 You can try out most of the ideas presented here by [running the examples](example-get-started.html).
@@ -39,7 +39,7 @@ Other than the connection string used for Solo, all other aspects of calling the
 
 ## Deploying scripts to Solo
 
-Scripts can be deployed and run on Solo using the [Solo CLI](starting-utils.html#deploying-running-dronekit-scripts-on-solo). The CLI takes care of packaging all the scripts in a folder along with all dependencies listed in the folder's **requirements.txt** file. It can then be used to transfer the package to Solo, install it, and run a specified script in a virtual environment.
+Scripts can be deployed and run on Solo using the [Solo CLI](starting-utils.html#deployingrunning-dronekit-scripts-on-solo). The CLI takes care of packaging all the scripts in a folder along with all dependencies listed in the folder's **requirements.txt** file. It can then be used to transfer the package to Solo, install it, and run a specified script in a virtual environment.
 
 <aside class="note">
 This approach has several benefits over using Solo's "inbuilt" version of DroneKit-Python:
@@ -47,7 +47,7 @@ This approach has several benefits over using Solo's "inbuilt" version of DroneK
 1. No Internet connection or reliance on package management on Solo is needed.
 1. Packages are installed in a virtual environment, so they don't collide with the global Solo namespace.
 1. You can always use the most recent DroneKit-Python in your examples (the inbuilt version is updated less regularly).
-1. The *Solo CLI* is simple to use and will already be present developer's computers.
+1. The *Solo CLI* is simple to use and will already be present developer's computers. 
 </aside>
 
 
@@ -65,7 +65,7 @@ The command is run inside a directory which should contain all needed Python scr
    ```
 
 <aside class="tip">
-The system will install fresh copies of any listed files into the script's virtual environment on Solo. The exception is OpenCV; if this is listed then a system version will be used instead.
+The system will install fresh copies of any listed files into the script's virtual environment on Solo. The exception is OpenCV; if this is listed then a system version will be used instead. 
 </aside>
 
 Open a terminal, navigate to the directory to package, and enter the following command:
@@ -81,7 +81,7 @@ After some processing, this will create an archive called `solo-script.tar.gz` i
 
 ### solo script run ...
 
-In order to deploy the script archive and run the app, first connect to Solo's wifi network.
+In order to deploy the script archive and run the app, first connect to Solo's wifi network. 
 
 Then enter the following command to upload the script archive to Solo, unpack it and its dependencies, and then attempt to run the specified python script (`yourscriptname.py`):
 
@@ -95,7 +95,7 @@ solo script run yourscriptname.py
 
 ## Accessing Solo Features
 
-DroneKit-Python scripts can use any features of the underlying platform that are (or can be made) accessible to Python.
+DroneKit-Python scripts can use any features of the underlying platform that are (or can be made) accessible to Python. 
 
 For example, DroneKit-Python does not have any API for direct access to camera/video (though it can control the Camera gimbal). However it can use platform services to access video frames and libraries like *OpenCv* for post-processing. See [this example](example-opencv.html) for more information.
 

--- a/book/concept-dronekit.md
+++ b/book/concept-dronekit.md
@@ -8,7 +8,7 @@ Solo uses [DroneKit-Python v1.1](http://python.dronekit.io/) internally to devel
 
 Working with DroneKit-Python is virtually the same on any platform/vehicle. Developers should read the [DroneKit-Python Documentation](http://python.dronekit.io/) in order to understand the key concepts.
 
-This topic provides a very brief introduction to the "nuances" of working with DroneKit-Python on Solo. It explains how a script should connect to Solo, how to deploy and run scripts on the device, some limitations of using DroneKit scripts (as opposed to using [Smart Shots](concept-smartshot.html)), and how to access useful platform features. 
+This topic provides a very brief introduction to the "nuances" of working with DroneKit-Python on Solo. It explains how a script should connect to Solo, how to deploy and run scripts on the device, some limitations of using DroneKit scripts (as opposed to using [Smart Shots](concept-smartshot.html)), and how to access useful platform features.
 
 <aside class="tip">
 You can try out most of the ideas presented here by [running the examples](example-get-started.html).
@@ -39,7 +39,7 @@ Other than the connection string used for Solo, all other aspects of calling the
 
 ## Deploying scripts to Solo
 
-Scripts can be deployed and run on Solo using the [Solo CLI](starting-utils.html#deployingrunning-dronekit-scripts-on-solo). The CLI takes care of packaging all the scripts in a folder along with all dependencies listed in the folder's **requirements.txt** file. It can then be used to transfer the package to Solo, install it, and run a specified script in a virtual environment.
+Scripts can be deployed and run on Solo using the [Solo CLI](starting-utils.html#deploying-running-dronekit-scripts-on-solo). The CLI takes care of packaging all the scripts in a folder along with all dependencies listed in the folder's **requirements.txt** file. It can then be used to transfer the package to Solo, install it, and run a specified script in a virtual environment.
 
 <aside class="note">
 This approach has several benefits over using Solo's "inbuilt" version of DroneKit-Python:
@@ -47,7 +47,7 @@ This approach has several benefits over using Solo's "inbuilt" version of DroneK
 1. No Internet connection or reliance on package management on Solo is needed.
 1. Packages are installed in a virtual environment, so they don't collide with the global Solo namespace.
 1. You can always use the most recent DroneKit-Python in your examples (the inbuilt version is updated less regularly).
-1. The *Solo CLI* is simple to use and will already be present developer's computers. 
+1. The *Solo CLI* is simple to use and will already be present developer's computers.
 </aside>
 
 
@@ -65,7 +65,7 @@ The command is run inside a directory which should contain all needed Python scr
    ```
 
 <aside class="tip">
-The system will install fresh copies of any listed files into the script's virtual environment on Solo. The exception is OpenCV; if this is listed then a system version will be used instead. 
+The system will install fresh copies of any listed files into the script's virtual environment on Solo. The exception is OpenCV; if this is listed then a system version will be used instead.
 </aside>
 
 Open a terminal, navigate to the directory to package, and enter the following command:
@@ -81,7 +81,7 @@ After some processing, this will create an archive called `solo-script.tar.gz` i
 
 ### solo script run ...
 
-In order to deploy the script archive and run the app, first connect to Solo's wifi network. 
+In order to deploy the script archive and run the app, first connect to Solo's wifi network.
 
 Then enter the following command to upload the script archive to Solo, unpack it and its dependencies, and then attempt to run the specified python script (`yourscriptname.py`):
 
@@ -95,7 +95,7 @@ solo script run yourscriptname.py
 
 ## Accessing Solo Features
 
-DroneKit-Python scripts can use any features of the underlying platform that are (or can be made) accessible to Python. 
+DroneKit-Python scripts can use any features of the underlying platform that are (or can be made) accessible to Python.
 
 For example, DroneKit-Python does not have any API for direct access to camera/video (though it can control the Camera gimbal). However it can use platform services to access video frames and libraries like *OpenCv* for post-processing. See [this example](example-opencv.html) for more information.
 

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,3 @@
+dependencies:
+  post:
+    - gitbook install book

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "url": "git+https://github.com/3drobotics/solodevguide.git"
   },
   "devDependencies": {
-    "gitbook": "~2.6.5",
     "gitbook-cli": "~1.0.1",
     "grunt": "~0.4.2",
     "grunt-bower-install-simple": "0.9.2",


### PR DESCRIPTION
not sure why we are having this problem with the tests, a `/book/_book/gitbook/website/` directory is not being created by the CI environments, I'll ask gitbook upstream.

For now the workaround was to omit the directory form the link crawler:

```js
crawler.addFetchCondition(function(url) {
  return !url.path.match(/\/website\//);
});
```
Tests remain red since there are real problems in the codebase, once this is in we can evaluate the problems