### PR TITLE
Fixes image rendering so they display on github

### DIFF
--- a/book/hardware-accessorybay.md
+++ b/book/hardware-accessorybay.md
@@ -70,14 +70,14 @@ An open source reference design for a breakout board can be found [here](https:/
 
 The breakout board plugs into the accessory port. The exposed side of the board is as shown below.
 
-![Accessory Breakout Board PCB (from below)](/images/accessory_breakout_board_pcb_below.jpg)
+![Accessory Breakout Board PCB (from below)](images/accessory_breakout_board_pcb_below.jpg)
 
 
 ## Communication Architecture
 
 The main communication channels between the Accessory Bay, Pixhawk and Companion Computer are shown below. Note that only USB is available for developer communication with Solo (the CAN and Serial/MAVLink channel is shown dashed for this reason). 
 
-![Accessory Bay System Architecture](/images/solo_accessory_bay_system_diagram.png)
+![Accessory Bay System Architecture](images/solo_accessory_bay_system_diagram.png)
 
 
 ## Communication Protocol


### PR DESCRIPTION
The old link works fine on SDG but doesn't render on github. This makes it work on both, which is "beneficial"
