### PR TITLE
Make tests pass again

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "grunt-contrib-requirejs": "0.4.1",
     "grunt-gitbook": "^1.5.0",
     "grunt-http-server": "^1.10.0",
-    "grunt-link-checker": "^0.1.0",
+    "grunt-link-checker": "OXINARF/grunt-link-checker",
     "mocha": "2.2.1",
     "should": "5.2.0"
   },


### PR DESCRIPTION
Following the discussion in #275:

grunt-link-checker has a bug that makes tests fail and until upstream is fixed a fork can be used. As I said there it's your decision to fork it yourselves or use my fixed fork, this PR just shows how to use the fork.